### PR TITLE
Update in_memory_session_interface.py

### DIFF
--- a/sanic_session/in_memory_session_interface.py
+++ b/sanic_session/in_memory_session_interface.py
@@ -65,8 +65,9 @@ class InMemorySessionInterface(BaseSessionInterface):
             return
 
         if not request['session']:
-            self.session_store.delete(
-                self.prefix + request['session'].sid)
+            if self.prefix + request['session'].sid in self.session_store:
+                self.session_store.delete(
+                    self.prefix + request['session'].sid)
 
             if request['session'].modified:
                 self._delete_cookie(request, response)


### PR DESCRIPTION
This will raise  KeyError exception, if we do not use request["session"].

```
"xxx/sanic_session/utils.py", line 112, in delete
    del self[key]
KeyError: 'session:fc46d8d890254821a0ce9b8c9af29a0d'
```

```
from sanic import Sanic
from sanic.response import text
from sanic_session import InMemorySessionInterface


app = Sanic()
session_interface = InMemorySessionInterface()

@app.middleware('request')
async def add_session_to_request(request):
    # before each request initialize a session
    # using the client's request
    await session_interface.open(request)


@app.middleware('response')
async def save_session(request, response):
    # after each request save the session,
    # pass the response to set client cookies
    await session_interface.save(request, response)

@app.route("/")
async def index(request):
    # interact with the session like a normal dict

    return text("request['session']['foo']")

if __name__ == "__main__":
    app.run(host="0.0.0.0", port=8000, debug=True)
```