### PR TITLE
bug: redis delete method accepts a list as argument

### DIFF
--- a/sanic_session/redis_session_interface.py
+++ b/sanic_session/redis_session_interface.py
@@ -82,11 +82,10 @@ class RedisSessionInterface(BaseSessionInterface):
         Returns:
             None
         """
-        redis_connection = await self.redis_getter()
-
         if 'session' not in request:
             return
 
+        redis_connection = await self.redis_getter()
         key = self.prefix + request['session'].sid
         if not request['session']:
             await redis_connection.delete([key])

--- a/tests/test_redis_session_interface.py
+++ b/tests/test_redis_session_interface.py
@@ -175,7 +175,7 @@ async def test_should_delete_session_from_redis(mocker, mock_redis, mock_dict):
     assert redis_connection.delete.call_count == 1
     assert(
         redis_connection.delete.call_args_list[0][0][0] ==
-        'session:{}'.format(SID))
+        ['session:{}'.format(SID)])
     assert response.cookies == {}, 'should not change response cookies'
 
 


### PR DESCRIPTION
according to `asyncio_redis` document [http://asyncio-redis.readthedocs.io/en/latest/pages/reference.html#asyncio_redis.RedisProtocol.delete](http://asyncio-redis.readthedocs.io/en/latest/pages/reference.html#asyncio_redis.RedisProtocol.delete), `delete` method accepts a list.

And, check session in request before getting redis connection and no need to get redis connection for first request