### PR TITLE
Correctly set expires and max-age in cookies

### DIFF
--- a/sanic_session/base.py
+++ b/sanic_session/base.py
@@ -1,3 +1,5 @@
+import time
+
 from sanic_session.utils import CallbackDict
 
 
@@ -12,6 +14,11 @@ class SessionDict(CallbackDict):
         self.modified = False
 
 
+def _calculate_expires(expiry):
+    expires = time.time() + expiry
+    return time.strftime("%a, %d-%b-%Y %T GMT", time.gmtime(expires))
+
+
 class BaseSessionInterface:
     def _delete_cookie(self, request, response):
         response.cookies[self.cookie_name] = request['session'].sid
@@ -20,7 +27,8 @@ class BaseSessionInterface:
 
     def _set_cookie_expiration(self, request, response):
         response.cookies[self.cookie_name] = request['session'].sid
-        response.cookies[self.cookie_name]['expires'] = self.expiry
+        response.cookies[self.cookie_name]['expires'] = _calculate_expires(self.expiry)
+        response.cookies[self.cookie_name]['max-age'] = self.expiry
         response.cookies[self.cookie_name]['httponly'] = self.httponly
 
         if self.domain:

--- a/tests/test_in_memory_session_interface.py
+++ b/tests/test_in_memory_session_interface.py
@@ -1,3 +1,4 @@
+import time
 from sanic.response import text
 from sanic_session.in_memory_session_interface import InMemorySessionInterface
 import pytest
@@ -179,6 +180,8 @@ async def test_should_reset_cookie_expiry(mocker, mock_dict):
 
     request = mock_dict()
     request.cookies = COOKIES
+    mocker.patch("time.time")
+    time.time.return_value = 1488576462.138493
 
     session_interface = InMemorySessionInterface(
         cookie_name=COOKIE_NAME)
@@ -193,3 +196,4 @@ async def test_should_reset_cookie_expiry(mocker, mock_dict):
 
     assert response.cookies[COOKIE_NAME].value == SID
     assert response.cookies[COOKIE_NAME]['max-age'] == 2592000
+    assert response.cookies[COOKIE_NAME]['expires'] == "Sun, 02-Apr-2017 21:27:42 GMT"

--- a/tests/test_in_memory_session_interface.py
+++ b/tests/test_in_memory_session_interface.py
@@ -192,4 +192,4 @@ async def test_should_reset_cookie_expiry(mocker, mock_dict):
     await session_interface.save(request, response)
 
     assert response.cookies[COOKIE_NAME].value == SID
-    assert response.cookies[COOKIE_NAME]['expires'] == 2592000
+    assert response.cookies[COOKIE_NAME]['max-age'] == 2592000

--- a/tests/test_memcache_session_interface.py
+++ b/tests/test_memcache_session_interface.py
@@ -241,4 +241,4 @@ async def test_should_reset_cookie_expiry(mock_dict, mock_memcache):
     await session_interface.save(request, response)
 
     assert response.cookies[COOKIE_NAME].value == SID
-    assert response.cookies[COOKIE_NAME]['expires'] == 2592000
+    assert response.cookies[COOKIE_NAME]['max-age'] == 2592000

--- a/tests/test_memcache_session_interface.py
+++ b/tests/test_memcache_session_interface.py
@@ -1,3 +1,4 @@
+import time
 from sanic.response import text
 from sanic_session.memcache_session_interface import MemcacheSessionInterface
 import pytest
@@ -223,7 +224,7 @@ async def test_should_save_in_memcache_for_time_specified(mock_dict, mock_memcac
 
 
 @pytest.mark.asyncio
-async def test_should_reset_cookie_expiry(mock_dict, mock_memcache):
+async def test_should_reset_cookie_expiry(mocker, mock_dict, mock_memcache):
     request = mock_dict()
     request.cookies = COOKIES
     memcache_connection = mock_memcache
@@ -231,6 +232,8 @@ async def test_should_reset_cookie_expiry(mock_dict, mock_memcache):
         ujson.dumps({'foo': 'bar'}).encode())
     memcache_connection.set = mock_coroutine()
     response = text('foo')
+    mocker.patch("time.time")
+    time.time.return_value = 1488576462.138493
 
     session_interface = MemcacheSessionInterface(
         memcache_connection,
@@ -242,3 +245,4 @@ async def test_should_reset_cookie_expiry(mock_dict, mock_memcache):
 
     assert response.cookies[COOKIE_NAME].value == SID
     assert response.cookies[COOKIE_NAME]['max-age'] == 2592000
+    assert response.cookies[COOKIE_NAME]['expires'] == "Sun, 02-Apr-2017 21:27:42 GMT"

--- a/tests/test_redis_session_interface.py
+++ b/tests/test_redis_session_interface.py
@@ -245,4 +245,4 @@ async def test_should_reset_cookie_expiry(mock_dict, mock_redis):
     await session_interface.save(request, response)
 
     assert response.cookies[COOKIE_NAME].value == SID
-    assert response.cookies[COOKIE_NAME]['expires'] == 2592000
+    assert response.cookies[COOKIE_NAME]['max-age'] == 2592000

--- a/tests/test_redis_session_interface.py
+++ b/tests/test_redis_session_interface.py
@@ -1,3 +1,4 @@
+import time
 from sanic.response import text
 from sanic_session.redis_session_interface import RedisSessionInterface
 import pytest
@@ -227,7 +228,7 @@ async def test_should_save_in_redis_for_time_specified(mock_dict, mock_redis):
 
 
 @pytest.mark.asyncio
-async def test_should_reset_cookie_expiry(mock_dict, mock_redis):
+async def test_should_reset_cookie_expiry(mocker, mock_dict, mock_redis):
     request = mock_dict()
     request.cookies = COOKIES
     redis_connection = mock_redis
@@ -235,6 +236,8 @@ async def test_should_reset_cookie_expiry(mock_dict, mock_redis):
     redis_connection.setex = mock_coroutine()
     redis_getter = mock_coroutine(redis_connection)
     response = text('foo')
+    mocker.patch("time.time")
+    time.time.return_value = 1488576462.138493
 
     session_interface = RedisSessionInterface(
         redis_getter,
@@ -246,3 +249,4 @@ async def test_should_reset_cookie_expiry(mock_dict, mock_redis):
 
     assert response.cookies[COOKIE_NAME].value == SID
     assert response.cookies[COOKIE_NAME]['max-age'] == 2592000
+    assert response.cookies[COOKIE_NAME]['expires'] == "Sun, 02-Apr-2017 21:27:42 GMT"


### PR DESCRIPTION
See the difference between `expires` and `max-age` here: http://mrcoles.com/blog/cookies-max-age-vs-expires/