### PR TITLE
Custom SID Generation

### DIFF
--- a/sanic_session/in_memory_session_interface.py
+++ b/sanic_session/in_memory_session_interface.py
@@ -1,16 +1,17 @@
 import ujson
+from typing import Callable
 from sanic_session.base import BaseSessionInterface, SessionDict
-from sanic_session.utils import ExpiringDict
-import uuid
+from sanic_session.utils import ExpiringDict, default_sid_generator
 
 
 class InMemorySessionInterface(BaseSessionInterface):
     def __init__(
             self, domain: str=None, expiry: int = 2592000,
             httponly: bool=True, cookie_name: str = 'session',
-            prefix: str='session:'):
+            prefix: str = 'session:', sid_generator: Callable[[], str] = default_sid_generator):
         self.expiry = expiry
         self.prefix = prefix
+        self.sid_generator = sid_generator
         self.cookie_name = cookie_name
         self.domain = domain
         self.httponly = httponly
@@ -34,7 +35,7 @@ class InMemorySessionInterface(BaseSessionInterface):
         sid = request.cookies.get(self.cookie_name)
 
         if not sid:
-            sid = uuid.uuid4().hex
+            sid = self.sid_generator()
             session_dict = SessionDict(sid=sid)
         else:
             val = self.session_store.get(self.prefix + sid)

--- a/sanic_session/utils.py
+++ b/sanic_session/utils.py
@@ -1,5 +1,13 @@
 import time
 from typing import Union, Any
+import uuid
+
+
+def default_sid_generator():
+    """
+    A default method of generating unique session identifiers based on UUID4.
+    """
+    return uuid.uuid4().hex
 
 
 class _Missing(object):

--- a/tests/test_in_memory_session_interface.py
+++ b/tests/test_in_memory_session_interface.py
@@ -18,7 +18,6 @@ def mock_dict():
 
     return MockDict
 
-
 @pytest.mark.asyncio
 async def test_should_create_new_sid_if_no_cookie(mocker, mock_dict):
     request = mock_dict()
@@ -30,6 +29,23 @@ async def test_should_create_new_sid_if_no_cookie(mocker, mock_dict):
 
     assert uuid.uuid4.call_count == 1, 'should create a new SID with uuid'
     assert request['session'] == {}, 'should return an empty dict as session'
+
+
+@pytest.mark.asyncio
+async def test_custom_sid_generator(mocker, mock_dict):
+    SID = "c0fe70cbd8ca8b798ceec7392bc3172c"
+
+    def custom_generator():
+        """A dummy SID generation protocol that returns a constant SID for unit testing"""
+        return SID
+
+    request = mock_dict()
+    request.cookies = {}
+
+    session_interface = InMemorySessionInterface(sid_generator=custom_generator)
+    await session_interface.open(request)
+
+    assert request["session"].sid == SID
 
 
 @pytest.mark.asyncio

--- a/tests/test_memcache_session_interface.py
+++ b/tests/test_memcache_session_interface.py
@@ -66,6 +66,25 @@ async def test_memcache_should_create_new_sid_if_no_cookie(
     assert uuid.uuid4.call_count == 1, 'should create a new SID with uuid'
     assert request['session'] == {}, 'should return an empty dict as session'
 
+@pytest.mark.asyncio
+async def test_memcache_custom_sid_generator(
+        mocker, mock_memcache, mock_dict):
+    SID = "c0fe70cbd8ca8b798ceec7392bc3172c"
+
+    def custom_generator():
+        """A dummy SID generation protocol that returns a constant SID for unit testing"""
+        return SID
+
+    request = mock_dict()
+    request.cookies = {}
+    memcache_connection = mock_memcache()
+    memcache_connection.get = mock_coroutine()
+
+    session_interface = MemcacheSessionInterface(memcache_connection, sid_generator=custom_generator)
+    await session_interface.open(request)
+
+    assert request["session"].sid == SID
+
 
 @pytest.mark.asyncio
 async def test_should_return_data_from_memcache(

--- a/tests/test_redis_session_interface.py
+++ b/tests/test_redis_session_interface.py
@@ -70,6 +70,27 @@ async def test_redis_should_create_new_sid_if_no_cookie(
 
 
 @pytest.mark.asyncio
+async def test_redis_custom_sid_generator(
+        mocker, mock_redis, mock_dict):
+    SID = "c0fe70cbd8ca8b798ceec7392bc3172c"
+
+    def custom_generator():
+        """A dummy SID generation protocol that returns a constant SID for unit testing"""
+        return SID
+
+    request = mock_dict()
+    request.cookies = {}
+    redis_connection = mock_redis()
+    redis_connection.get = mock_coroutine()
+    redis_getter = mock_coroutine(redis_connection)
+
+    session_interface = RedisSessionInterface(redis_getter, sid_generator=custom_generator)
+    await session_interface.open(request)
+
+    assert request["session"].sid == SID
+
+
+@pytest.mark.asyncio
 async def test_should_return_data_from_redis(mocker, mock_dict, mock_redis):
     request = mock_dict()
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,15 @@
-from sanic_session.utils import ExpiringDict
+from sanic_session.utils import ExpiringDict, default_sid_generator
+import uuid
+import pytest
+
+
+def test_default_sid_generator():
+    sid = default_sid_generator()
+    try:
+        val = uuid.UUID(sid, version=4)
+    except ValueError:
+        pytest.fail("Invalid UUID")
+    assert val.hex == sid
 
 
 def test_sets_expiry_internally():


### PR DESCRIPTION
I wanted a way to provide my own method of generating session identifiers instead of the default UUID4 method. I added a new optional parameter `sid_generator` to each of the session interface classes which stores the value as `self.sid_generator`. The default value is a new function in `sanic_session.utils` called `default_sid_generator` which simply returns `uuid.uuid4().hex`. Docstrings have been updated where available and unit tests have been written to test custom SID generation as well as UUID4 validation for the default generator.