### PR TITLE
Add support for 'session cookies'

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -15,8 +15,10 @@ When initializing a session interface, you have a number of optional arguments f
     Name used for the client cookie. Defaults to "session".
 **prefix** (str, optional):
     Storage keys will take the format of `prefix+<session_id>`. Specify the prefix here.
+**sessioncookie** (bool, optional):
+    If enabled the browser will be instructed to delete the cookie when the browser is closed. This is done by omitting the `max-age` and `expires` headers when sending the cookie. The `expiry` configuration option will still be honored on the server side. This is option is disabled by default.
 
-**Example:**
+**Example 1:**
 
 .. code-block:: python
 
@@ -30,4 +32,21 @@ Will result in a session that:
 - Will never expire. 
 - Will be accessible by Javascript.
 - Will be named "cookie" on the client.
-- will be named "sessionprefix:<sid>" in the session store.
+- Will be named "sessionprefix:<sid>" in the session store.
+
+**Example 2:**
+
+.. code-block:: python
+
+    session_interface = InMemorySessionInterface(
+        domain='.example.com', expiry=3600, sessioncookie=True,
+        httponly=True, cookie_name="myapp", prefix="session:")
+
+Will result in a session that:
+
+- Will be valid only on *example.com*.
+- Will expire on the server side after 1 hour.
+- Will be deleted on the client when the user closes the browser.
+- Will *not* be accessible by Javascript.
+- Will be named "myapp" on the client.
+- Will be named "session:<sid>" in the session store.

--- a/sanic_session/base.py
+++ b/sanic_session/base.py
@@ -22,14 +22,19 @@ def _calculate_expires(expiry):
 class BaseSessionInterface:
     def _delete_cookie(self, request, response):
         response.cookies[self.cookie_name] = request['session'].sid
+
+        # We set expires/max-age even for session cookies to force expiration
         response.cookies[self.cookie_name]['expires'] = 0
         response.cookies[self.cookie_name]['max-age'] = 0
 
     def _set_cookie_expiration(self, request, response):
         response.cookies[self.cookie_name] = request['session'].sid
-        response.cookies[self.cookie_name]['expires'] = _calculate_expires(self.expiry)
-        response.cookies[self.cookie_name]['max-age'] = self.expiry
         response.cookies[self.cookie_name]['httponly'] = self.httponly
+
+        # Set expires and max-age unless we are using session cookies
+        if not self.sessioncookie:
+            response.cookies[self.cookie_name]['expires'] = _calculate_expires(self.expiry)
+            response.cookies[self.cookie_name]['max-age'] = self.expiry
 
         if self.domain:
             response.cookies[self.cookie_name]['domain'] = self.domain

--- a/sanic_session/in_memory_session_interface.py
+++ b/sanic_session/in_memory_session_interface.py
@@ -8,13 +8,15 @@ class InMemorySessionInterface(BaseSessionInterface):
     def __init__(
             self, domain: str=None, expiry: int = 2592000,
             httponly: bool=True, cookie_name: str = 'session',
-            prefix: str='session:'):
+            prefix: str='session:',
+            sessioncookie: bool=False):
         self.expiry = expiry
         self.prefix = prefix
         self.cookie_name = cookie_name
         self.domain = domain
         self.httponly = httponly
         self.session_store = ExpiringDict()
+        self.sessioncookie = sessioncookie
 
     async def open(self, request) -> SessionDict:
         """Opens an in-memory session onto the request. Restores the client's session

--- a/sanic_session/memcache_session_interface.py
+++ b/sanic_session/memcache_session_interface.py
@@ -7,7 +7,8 @@ class MemcacheSessionInterface(BaseSessionInterface):
             self, memcache_connection,
             domain: str=None, expiry: int = 2592000,
             httponly: bool=True, cookie_name: str = 'session',
-            prefix: str = 'session:'):
+            prefix: str = 'session:',
+            sessioncookie: bool=False):
         """Initializes the interface for storing client sessions in memcache.
         Requires a client object establised with `asyncio_memcache`.
 
@@ -25,6 +26,11 @@ class MemcacheSessionInterface(BaseSessionInterface):
             prefix (str, optional):
                 Memcache keys will take the format of `prefix+session_id`;
                 specify the prefix here.
+            sessioncookie (bool, optional):
+                Specifies if the sent cookie should be a 'session cookie', i.e
+                no Expires or Max-age headers are included. Expiry is still
+                fully tracked on the server side. Default setting is False.
+
         """
         self.memcache_connection = memcache_connection
 
@@ -38,6 +44,7 @@ class MemcacheSessionInterface(BaseSessionInterface):
         self.cookie_name = cookie_name
         self.domain = domain
         self.httponly = httponly
+        self.sessioncookie = sessioncookie
 
     async def open(self, request) -> dict:
         """Opens a session onto the request. Restores the client's session

--- a/sanic_session/mongodb_session_interface.py
+++ b/sanic_session/mongodb_session_interface.py
@@ -28,7 +28,9 @@ class MongoDBSessionInterface(BaseSessionInterface):
             domain: str=None,
             expiry: int=30*24*60*60,
             httponly: bool=True,
-            cookie_name: str='session'):
+            cookie_name: str='session',
+            sessioncookie: bool=False):
+
         """Initializes the interface for storing client sessions in MongoDB.
 
         Args:
@@ -44,11 +46,17 @@ class MongoDBSessionInterface(BaseSessionInterface):
                 Adds the `httponly` flag to the session cookie.
             cookie_name (str, optional):
                 Name used for the client cookie.
+            sessioncookie (bool, optional):
+                Specifies if the sent cookie should be a 'session cookie', i.e
+                no Expires or Max-age headers are included. Expiry is still
+                fully tracked on the server side. Default setting is False.
+
         """
         self.expiry = expiry
         self.cookie_name = cookie_name
         self.domain = domain
         self.httponly = True
+        self.sessioncookie = sessioncookie
 
         # set collection name
         _SessionModel.__coll__ = coll

--- a/sanic_session/redis_session_interface.py
+++ b/sanic_session/redis_session_interface.py
@@ -10,7 +10,8 @@ class RedisSessionInterface(BaseSessionInterface):
             self, redis_getter: Callable,
             domain: str=None, expiry: int = 2592000,
             httponly: bool=True, cookie_name: str='session',
-            prefix: str='session:'):
+            prefix: str='session:',
+            sessioncookie: bool=False):
         """Initializes a session interface backed by Redis.
 
         Args:
@@ -28,6 +29,10 @@ class RedisSessionInterface(BaseSessionInterface):
             prefix (str, optional):
                 Memcache keys will take the format of `prefix+session_id`;
                 specify the prefix here.
+            sessioncookie (bool, optional):
+                Specifies if the sent cookie should be a 'session cookie', i.e
+                no Expires or Max-age headers are included. Expiry is still
+                fully tracked on the server side. Default setting is False.
         """
         self.redis_getter = redis_getter
         self.expiry = expiry
@@ -35,6 +40,7 @@ class RedisSessionInterface(BaseSessionInterface):
         self.cookie_name = cookie_name
         self.domain = domain
         self.httponly = httponly
+        self.sessioncookie = sessioncookie
 
     async def open(self, request):
         """Opens a session onto the request. Restores the client's session

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,10 @@ try:
 except:
     long_description = ''
 
+
+# Set requirements here
+requirements = ('sanic', 'sanic_motor', 'ujson')
+
 setup(
     name='sanic_session',
     version='0.1.3',
@@ -15,7 +19,13 @@ setup(
     author='Suby Raman',
     license='MIT',
     packages=['sanic_session'],
-    install_requires=('sanic', 'sanic_motor', 'ujson'),
+    # Kludge: Specifying requirements for setup and install works around
+    # problem with easyinstall finding sanic_motor instead of sanic.
+    # See similar problem:
+    #   https://stackoverflow.com/questions/27497470/setuptools-finds-wrong-package-during-install
+    #   https://github.com/numpy/numpy/issues/2434
+    setup_requires=requirements,
+    install_requires=requirements,
     zip_safe=False,
     keywords=['sessions', 'sanic', 'redis', 'memcache'],
     classifiers=[


### PR DESCRIPTION
Some applications prefer having cookies deleted by the users browser
when the browser is closed. This is achieved by not setting
max-age nor expires headers.